### PR TITLE
remove android:allowBackup="true"

### DIFF
--- a/zoomy/src/main/AndroidManifest.xml
+++ b/zoomy/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.ablanco.zoomy">
 
-    <application android:allowBackup="true" android:label="@string/app_name"
+    <application android:label="@string/app_name"
         android:supportsRtl="true">
 
     </application>


### PR DESCRIPTION
# Problem 
not a library allowBackup is wrongly used in a library

# See for more info
https://github.com/imablanco/Zoomy/issues/22