### PR TITLE
onViewBeforeStartedZooming Callback

### DIFF
--- a/zoomy/build.gradle
+++ b/zoomy/build.gradle
@@ -13,7 +13,7 @@ ext {
     siteUrl = 'https://github.com/imablanco/Zoomy'
     gitUrl = 'https://github.com/imablanco/Zoomy.git'
 
-    libraryVersion = '1.1.0'
+    libraryVersion = '1.1.1'
 
     developerId = 'ablanco'
     developerName = 'Alvaro Blanco'

--- a/zoomy/src/main/java/com/ablanco/zoomy/ZoomListener.java
+++ b/zoomy/src/main/java/com/ablanco/zoomy/ZoomListener.java
@@ -8,6 +8,7 @@ import android.view.View;
  */
 
 public interface ZoomListener {
+    void onViewBeforeStartedZooming(View view);
     void onViewStartedZooming(View view);
     void onViewEndedZooming(View view);
 }

--- a/zoomy/src/main/java/com/ablanco/zoomy/ZoomableTouchListener.java
+++ b/zoomy/src/main/java/com/ablanco/zoomy/ZoomableTouchListener.java
@@ -186,6 +186,8 @@ class ZoomableTouchListener implements View.OnTouchListener, ScaleGestureDetecto
 
 
     private void startZoomingView(View view) {
+        if (mZoomListener != null) mZoomListener.onViewBeforeStartedZooming(mTarget);
+
         mZoomableView = new ImageView(mTarget.getContext());
         mZoomableView.setLayoutParams(new ViewGroup.LayoutParams(mTarget.getWidth(), mTarget.getHeight()));
         mZoomableView.setImageBitmap(ViewUtils.getBitmapFromView(view));


### PR DESCRIPTION
As part of the `zoomListener` - it's a callback that's called *before* zooming starts.
This is useful in cases we want to manipulate the image/view being displayed, before the zooming starts.

For example - ImageView with a center-crop scale type, that we want to show fully (fit-center) when zooming in.